### PR TITLE
version 0.4.92, different from pre dbus-session 0.4.90

### DIFF
--- a/socranop/constants.py
+++ b/socranop/constants.py
@@ -32,7 +32,7 @@
 
 # Package name
 PACKAGE = "socranop"
-VERSION = "0.4.90"
+VERSION = "0.4.92"
 
 # Executable names
 BASE_EXE_CLI = "socranop-ctl"


### PR DESCRIPTION
Call it a different version so that we have a better idea
what someone is running when report sucesses or failures.

I forgot to update the version number when merging the
dbus-session and the big rename, so this catches up on that.