### PR TITLE
Add man pages for executables used at run time

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -1,0 +1,9 @@
+How to set up the device permissions
+====================================
+
+
+TODO: Linux/udev
+================
+
+
+TODO: How to install this file so that man pages can refer to it.

--- a/socranop/cli.py
+++ b/socranop/cli.py
@@ -85,6 +85,9 @@ def show(dev):
 
 
 def main():
+    # Caution: If you change the command line parser in any way,
+    #          update the man pages and bash completions accordingly.
+
     parser = argparse.ArgumentParser()
     common.parser_args(parser)
 

--- a/socranop/common.py
+++ b/socranop/common.py
@@ -36,6 +36,9 @@ def debug(*args, **kwargs):
 
 
 def parser_args(parser):
+    # Caution: If you change the command line parser in any way,
+    #          update the man pages and bash completions accordingly.
+
     parser.add_argument(
         "--version",
         action="version",

--- a/socranop/data/bash-completion/socranop-ctl
+++ b/socranop/data/bash-completion/socranop-ctl
@@ -1,0 +1,20 @@
+# bash completion script for the socranop-ctl command   -*- shell-script -*-
+
+_socranop_ctl()
+{
+    # $1 is the command name
+    # $2 is the word being completed
+    # $3 is the preceding word
+    case "$3" in
+	socranop-ctl | */socranop-ctl)
+	    COMPREPLY=($(compgen -W "-h --help --version -v --verbose --no-dbus -l --list -s --set" -- "$2"))
+	    return
+	    ;;
+        -s | --set)
+            COMPREPLY=($(compgen -W "0 1 2 3" -- "$2"))
+            return
+	    ;;
+    esac
+    return
+} &&
+    complete -F _socranop_ctl "socranop-ctl"

--- a/socranop/data/bash-completion/socranop-gui
+++ b/socranop/data/bash-completion/socranop-gui
@@ -1,0 +1,17 @@
+# bash completion script for the socranop-gui command   -*- shell-script -*-
+
+_socranop_gui()
+{
+    # $1 is the command name
+    # $2 is the word being completed
+    # $3 is the preceding word
+    case "$3" in
+	socranop-gui | */socranop-gui)
+	    # only common completions, other options need to be typed in
+	    COMPREPLY=($(compgen -W "-h --help --help-all --version -v --verbose" -- "$2"))
+	    return
+	    ;;
+    esac
+    return
+} &&
+    complete -F _socranop_gui "socranop-gui"

--- a/socranop/data/bash-completion/socranop-installtool
+++ b/socranop/data/bash-completion/socranop-installtool
@@ -1,0 +1,67 @@
+# bash completion script for the socranop-installtool command   -*- shell-script -*-
+
+_socranop_installtool()
+{
+    # $1 is the command name
+    # $2 is the word being completed
+    # $3 is the preceding word
+    local i word
+    local ALL_OPTIONS REMAINING_OPTIONS
+    declare -A REMAINING_OPTIONS
+
+    ALL_OPTIONS=(-h --help --version -v --verbose --post-install --pre-uninstall --no-launch --chroot --sudo-script)
+
+    case "$3" in
+	# socranop-installtool | */socranop-installtool)
+	#     COMPREPLY=($(compgen -W "${ALL_OPTIONS[*]}" -- "$2"))
+	#     return 0
+	#     ;;
+	--chroot)
+	    COMPREPLY=($(compgen -A directory -- "$2"))
+	    return 0
+	    ;;
+	--sudo-script)
+	    COMPREPLY=($(compgen -A file -- "$2"))
+	    return 0
+	    ;;
+    esac
+
+    for word in "${ALL_OPTIONS[@]}"
+    do
+	REMAINING_OPTIONS["$word"]=moo
+    done
+
+    for i in $(seq 0 "$(( $COMP_CWORD - 1 ))")
+    do
+	word="${COMP_WORDS[$i]}"
+	case "$word" in
+	    -h | --help | --version)
+		COMPREPLY=()
+		return 0
+		;;
+	    -v | --verbose)
+		unset REMAINING_OPTIONS["-v"]
+		unset REMAINING_OPTIONS["--verbose"]
+		;;
+	    --post-install)
+		unset REMAINING_OPTIONS["$word"]
+		unset REMAINING_OPTIONS["--pre-uninstall"]
+		;;
+	    --pre-uninstall)
+		unset REMAINING_OPTIONS["$word"]
+		unset REMAINING_OPTIONS["--post-install"]
+		;;
+	    --chroot)
+		unset REMAINING_OPTIONS["$word"]
+		unset REMAINING_OPTIONS["--no-launch"]
+		;;
+	    *)
+		unset REMAINING_OPTIONS["$word"]
+		;;
+	esac
+    done
+
+    COMPREPLY=($(compgen -W "${!REMAINING_OPTIONS[*]}" -- "$2"))
+    return 0
+} &&
+    complete -F _socranop_installtool "socranop-installtool"

--- a/socranop/data/bash-completion/socranop-session-service
+++ b/socranop/data/bash-completion/socranop-session-service
@@ -1,0 +1,16 @@
+# bash completion script for the socranop-session-service command   -*- shell-script -*-
+
+_socranop_session_service()
+{
+    # $1 is the command name
+    # $2 is the word being completed
+    # $3 is the preceding word
+    case "$3" in
+	socranop-session-service | */socranop-session-service)
+	    COMPREPLY=($(compgen -W "-h --help --version -v --verbose" -- "$2"))
+	    return
+	    ;;
+    esac
+    return
+} &&
+    complete -F _socranop_session_service "socranop-session-service"

--- a/socranop/data/man/socranop-ctl.1
+++ b/socranop/data/man/socranop-ctl.1
@@ -1,0 +1,160 @@
+.\" ======================================================================
+.\"
+.\" The socranop-ctl(1) man page
+.\"
+.\" This man page has been (re)written adhering to the following
+.\" documentation: man(7), man-pages(7), tbl(1)
+.\"
+.\" ======================================================================
+.\"
+.TH SOCRANOP\-CTL 1 "2021\-07\-04" "${PACKAGE} ${VERSION}" "User commands"
+.\"
+.\" ======================================================================
+.\"
+.SH NAME
+socranop\-ctl \- control Soundcraft Notepad series mixer USB audio routing from command line
+.\"
+.\" ======================================================================
+.\"
+.\" usage: socranop-ctl [-h] [--version] [--no-dbus] [-l] [-s SET]
+.\"
+.\" optional arguments:
+.\"   -h, --help         show this help message and exit
+.\"   --version          show program's version number and exit
+.\"   -v, --verbose      Enable more verbose output, largely for debugging
+.\"   --no-dbus          Use direct USB device access instead of D-Bus service
+.\"                      access
+.\"   -l, --list         List the available source routing options
+.\"   -s SET, --set SET  Set the specified source to route to the USB capture
+.\"                      input
+.\"
+.SH SYNOPSIS
+.B "socranop\-ctl"
+.RB (\| \-\-help \|| \-\-version \|)
+.br
+.B "socranop\-ctl"
+.RB [\| \-\-verbose \|]
+.RB [\| \-\-no\-dbus \|]
+.B \-\-list
+.br
+.B "socranop\-ctl"
+.RB [\| \-\-verbose \|]
+.RB [\| \-\-no\-dbus \|]
+.BI \-\-set\  SOURCE
+.\"
+.\" ======================================================================
+.\"
+.SH DESCRIPTION
+\fBsocranop\-ctl\fR allows controlling a Soundcraft Notepad series
+mixer from the command line.
+.\"
+.\" ======================================================================
+.\"
+.SH OPTIONS
+.TP
+.B \-\-help
+Print command line help and exit.
+.TP
+.B \-\-version
+Print the program version and exit.
+.TP
+.B \-\-no\-dbus
+Access the USB directly without going through the
+.B socranop\-session\-service
+D-Bus service.
+.TP
+.RB (\| \-v | \-\-verbose \|)
+Make the program output more information. Helpful for debugging.
+.TP
+.RB (\| \-l | \-\-list \|)
+List the available source routing options. This includes the current routing, if known.
+.TP
+.RB (\| \-s | \-\-set \|) \ \fIN\fR
+Set the source \fIN\fR to route to the USB capture input.
+.\"
+.\" ======================================================================
+.\"
+.SH EXIT STATUS
+If successful, returns 0. Non-0 exit codes indicate an error.
+.\"
+.\" ======================================================================
+.\"
+.SH ENVIRONMENT
+.TP
+.B XDG_CONFIG_HOME
+Used when \fBscoranop\-ctl\fR is run with \-\-no\-dbus. See the state file description in the FILES section below.
+.\"
+.\" ======================================================================
+.\"
+.SH FILES
+.TP
+.B ~/.config/${PACKAGE}/state/*.state
+The state file keeps track of the state the device has been set to.
+.IP
+If \fBsocranop\-ctl\fR is run without \fB\-\-no\-dbus\fR, see the \fBsocranop\-session\-service\fR(1) FILES section as \fBsocranop\-session\-service\fR will handle the state file including its location on behalf of \fBsocranop\-ctl\fR.
+.IP
+When \fBsocranop\-ctl\fR is run with \fB\-\-no\-dbus\fR, \fBsocranop\-ctl\fR handles the state file itself. If the \fBXDG_CONFIG_HOME\fR environment variable is set, its value will replace the \fB~/.config\fR part of the state file name.
+.\"
+.\" ======================================================================
+.\"
+.\" .SH NOTES
+.\"
+.\" ======================================================================
+.\"
+.SH BUGS
+For reading about known bugs and for filing new bugs, please go visit
+.UR https://github.com/socratools/socranop/issues
+.UE .
+.\"
+.\" ======================================================================
+.\"
+.SH EXAMPLES
+.PP
+.\" Note that the actual program output contains trailing spaces.
+ \" We have removed those for a nicer man page.
+    [user@host ~]$$ socranop-ctl --list
+    Detected a Notepad-12FX (fw v1.09)
+    -----------------------------
+    capture_1 <- Mic/Line 1
+    capture_2 <- Mic/Line 2
+    -----------------------------
+                 Mic/Line 3   [0]
+                 Mic/Line 4
+                 Stereo 5/6 L [1]
+                 Stereo 5/6 R
+    capture_3 <- Stereo 7/8 L [2]
+    capture_4 <- Stereo 7/8 R
+                 Mix L        [3]
+                 Mix R
+    -----------------------------
+    [user@host ~]$$ _
+.PP
+    [user@host ~]$$ socranop-ctl --set 3
+    Detected a Notepad-12FX (fw v1.09)
+    -----------------------------
+    capture_1 <- Mic/Line 1
+    capture_2 <- Mic/Line 2
+    -----------------------------
+                 Mic/Line 3   [0]
+                 Mic/Line 4
+                 Stereo 5/6 L [1]
+                 Stereo 5/6 R
+                 Stereo 7/8 L [2]
+                 Stereo 7/8 R
+    capture_3 <- Mix L        [3]
+    capture_4 <- Mix R
+    -----------------------------
+    [user@host ~]$$ _
+.\"
+.\" ======================================================================
+.\"
+.SH SEE ALSO
+.BR socranop\-gui (1),
+.BR socranop\-session\-service (1)
+.\"
+.\" ======================================================================
+.\"
+.\" THE END (of this man page).
+.\"
+.\" ======================================================================
+.\"

--- a/socranop/data/man/socranop-ctl.1
+++ b/socranop/data/man/socranop-ctl.1
@@ -82,22 +82,25 @@ If successful, returns 0. Non-0 exit codes indicate an error.
 .SH ENVIRONMENT
 .TP
 .B XDG_CONFIG_HOME
-Used when \fBscoranop\-ctl\fR is run with \-\-no\-dbus. See the state file description in the FILES section below.
+When \fBsocranop\-ctl\fR is run with \fB\-\-no\-dbus\fR, it takes over handling device file and state files from \fBsocranop\-session\-service\fR(1). See the \fBsocranop\-session\-service\fR(1) ENVIRONMENT and FILES sections for more information.
 .\"
 .\" ======================================================================
 .\"
 .SH FILES
+.\" The device path is Linux specific
+.BI /dev/bus/usb/ NNN / MMM
+When \fBsocranop\-ctl\fR is run with \fB\-\-no\-dbus\fR, it takes over handling device file and state files from \fBsocranop\-session\-service\fR(1). See the \fBsocranop\-session\-service\fR(1) ENVIRONMENT and FILES sections for more information.
 .TP
 .B ~/.config/${PACKAGE}/state/*.state
-The state file keeps track of the state the device has been set to.
-.IP
-If \fBsocranop\-ctl\fR is run without \fB\-\-no\-dbus\fR, see the \fBsocranop\-session\-service\fR(1) FILES section as \fBsocranop\-session\-service\fR will handle the state file including its location on behalf of \fBsocranop\-ctl\fR.
-.IP
-When \fBsocranop\-ctl\fR is run with \fB\-\-no\-dbus\fR, \fBsocranop\-ctl\fR handles the state file itself. If the \fBXDG_CONFIG_HOME\fR environment variable is set, its value will replace the \fB~/.config\fR part of the state file name.
+When \fBsocranop\-ctl\fR is run with \fB\-\-no\-dbus\fR, it takes over handling device file and state files from \fBsocranop\-session\-service\fR(1). See the \fBsocranop\-session\-service\fR(1) ENVIRONMENT and FILES sections for more information.
 .\"
 .\" ======================================================================
 .\"
-.\" .SH NOTES
+.SH NOTES
+When \fBsocranop\-ctl\fR is run with \fB\-\-no\-dbus\fR, the USB device file must be readable and writable for the \fBsocranop\-ctl\fR process. For more information on permission setup, see the
+.\" FIXME: Substitute the proper path to PERMISSIONS.md here.
+.B PERMISSIONS.md
+file.
 .\"
 .\" ======================================================================
 .\"
@@ -150,7 +153,9 @@ For reading about known bugs and for filing new bugs, please go visit
 .\"
 .SH SEE ALSO
 .BR socranop\-gui (1),
-.BR socranop\-session\-service (1)
+.BR socranop\-session\-service (1),
+.\" FIXME: Substitute the proper path to PERMISSIONS.md here.
+.B PERMISSIONS.md
 .\"
 .\" ======================================================================
 .\"

--- a/socranop/data/man/socranop-gui.1
+++ b/socranop/data/man/socranop-gui.1
@@ -1,0 +1,132 @@
+.\" ======================================================================
+.\"
+.\" The socranop-gui(1) man page
+.\"
+.\" This man page has been (re)written adhering to the following
+.\" documentation: man(7), man-pages(7), tbl(1)
+.\"
+.\" ======================================================================
+.\"
+.TH SOCRANOP-GUI 1 "2021\-07\-04" "${PACKAGE} ${VERSION}" "User commands"
+.\"
+.\" ======================================================================
+.\"
+.SH NAME
+socranop\-gui \- control Soundcraft Notepad series mixer USB audio routing from GUI
+.\"
+.\" ======================================================================
+.\" socranop-gui --help-all | sed 's|^|.\\" |
+.\" ======================================================================
+.\"
+.\" Usage:
+.\"   socranop-gui [OPTION…]
+.\"
+.\" Help Options:
+.\"   -h, --help                 Show help options
+.\"   --help-all                 Show all help options
+.\"   --help-gapplication        Show GApplication options
+.\"   --help-gtk                 Show GTK+ Options
+.\"
+.\" GApplication options
+.\"   --gapplication-service     Enter GApplication service mode (use from D-Bus service files)
+.\"
+.\" GTK+ Options
+.\"   --class=CLASS              Program class as used by the window manager
+.\"   --name=NAME                Program name as used by the window manager
+.\"   --gdk-debug=FLAGS          GDK debugging flags to set
+.\"   --gdk-no-debug=FLAGS       GDK debugging flags to unset
+.\"   --gtk-module=MODULES       Load additional GTK+ modules
+.\"   --g-fatal-warnings         Make all warnings fatal
+.\"   --gtk-debug=FLAGS          GTK+ debugging flags to set
+.\"   --gtk-no-debug=FLAGS       GTK+ debugging flags to unset
+.\"
+.\" Application Options:
+.\"   --version                  Show program's version number and exit
+.\"   -v, --verbose              Enable more verbose output, largely for debugging
+.\"   --display=DISPLAY          X display to use
+.\"
+.SH SYNOPSIS
+.B socranop\-gui
+.RB (\| \-\-help \|| \-\-version \|)
+.br
+.B "socranop\-ctl"
+.RB [\| \-\-verbose \|]
+.\"
+.\" ======================================================================
+.\"
+.SH DESCRIPTION
+.PP
+.B socranop\-gui
+is the GUI interface to change the USB audio routing on a Notepad series mixer. It works by communicating with D-Bus to the (bus activated) D-Bus service
+.B socranop\-session\-service
+which does the actual talking to the USB device.
+.PP
+Note that
+.B socranop\-gui
+is
+.B NOT
+a D-Bus service, so the
+.B \-\-gapplication\-service
+is
+.B unsupported.
+.\"
+.\" ======================================================================
+.\"
+.SH OPTIONS
+In addition to the options shown below, \fBsocranop\-gui\fR supports a large set of Gtk+ and GApplication related options which are documented elsewhere.
+.TP
+.B \-\-help
+Print command line help and exit.
+.TP
+.B \-\-version
+Print the program version and exit.
+.TP
+.RB (\| \-v | \-\-verbose \|)
+Make the program output more information. Helpful for debugging.
+.\"
+.\" ======================================================================
+.\"
+.SH EXIT STATUS
+If successful, returns 0. Non-0 exit codes indicate an error.
+.\"
+.\" ======================================================================
+.\"
+.\" .SH ENVIRONMENT
+.\"
+.\" ======================================================================
+.\"
+.SH FILES
+.TP
+.B ${datadir}/icons/hicolor/256x256/apps/${APPLICATION_ID}.png
+One location where \fBsocranop\-gui\fR looks for its application icon.
+.TP
+.B ${socranopdir}/data/xdg/${APPLICATION_ID}.256.png
+Fallback location where \fBsocranop\-gui\fR looks for its application icon.
+.\"
+.\" ======================================================================
+.\"
+.\" .SH NOTES
+.\"
+.\" ======================================================================
+.\"
+.SH BUGS
+For reading about known bugs and for filing new bugs, please go visit
+.UR https://github.com/socratools/socranop/issues
+.UE .
+.\"
+.\" ======================================================================
+.\"
+.\" .SH EXAMPLES
+.\"
+.\" ======================================================================
+.\"
+.SH SEE ALSO
+.BR socranop\-ctl (1),
+.BR socranop\-session\-service (1)
+.\"
+.\" ======================================================================
+.\"
+.\" THE END (of this man page).
+.\"
+.\" ======================================================================
+.\"

--- a/socranop/data/man/socranop-session-service.1
+++ b/socranop/data/man/socranop-session-service.1
@@ -1,0 +1,134 @@
+.\" ======================================================================
+.\"
+.\" The socranop-session-service(1) man page
+.\"
+.\" This man page has been (re)written adhering to the following
+.\" documentation: man(7), man-pages(7), tbl(1)
+.\"
+.\" ======================================================================
+.\"
+.TH SOCRANOP\-SESSION\-SERVICE 1 "2021\-07\-04" "${PACKAGE} ${VERSION}" "User commands"
+.\"
+.\" ======================================================================
+.\"
+.SH NAME
+socranop\-session\-service \- session D\-Bus service for socranop
+.\"
+.\" ======================================================================
+.\"
+.\" usage: socranop-session-service [-h] [--version]
+.\"
+.\" The socranop D-Bus service.
+.\"
+.\" optional arguments:
+.\"   -h, --help     show this help message and exit
+.\"   --version      show program's version number and exit
+.\"   -v, --verbose  Enable more verbose output, largely for debugging
+.\"
+.SH SYNOPSIS
+.B "socranop\-session\-service"
+.RB (\| \-\-help \|| \-\-version \|)
+.br
+.B "socranop\-session\-service"
+.RB [\| \-\-verbose \|]
+.\"
+.\" ======================================================================
+.\"
+.SH DESCRIPTION
+.PP
+The
+.B "socranop\-session\-service"
+D\-Bus service is bus activated, so it does not need to be run
+explicity in normal operation.
+.PP
+The D\-Bus service fulfils two main functions:
+.IP "stand in for the mixer state" 8
+As the Notepad series of mixers does not appear to have a USB command to query the state which can be set with a USB command, the D\-Bus service remembers the hardware state to provide a halfway sane behaviour.
+.IP "notify other processes of mixer state changes"
+If you have e.g. a
+.B "socranop-gui"
+window open, and change the mixer state from the command line with
+.BR "socranop-ctl \-\-set" ,
+the
+.B "socranop-gui"
+window will show that state change immediately.
+.\"
+.\" ======================================================================
+.\"
+.SH OPTIONS
+.PP
+If no options are given on the command line,
+.B socranop\-session\-service
+will just start as a D\-Bus service and keep running until a D\-Bus
+client requests it to shut down.
+.TP
+.BR \-\-help
+Print command line help and exit.
+.TP
+.BR \-\-version
+Print the program version and exit.
+.TP
+.RB (\| \-v | \-\-verbose \|)
+Make the program output more information. Helpful for debugging.
+.\"
+.\" ======================================================================
+.\"
+.SH EXIT STATUS
+If successful, returns 0. Non-0 exit codes indicate an error.
+.\"
+.\" ======================================================================
+.\"
+.SH ENVIRONMENT
+.TP
+.B XDG_CONFIG_HOME
+See the state file description in the FILES section below.
+.\"
+.\" ======================================================================
+.\"
+.SH FILES
+.TP
+.B ~/.config/${PACKAGE}/state/*.state
+The state file is used to keep track of the state the device has been set to.
+.IP
+If the \fBXDG_CONFIG_HOME\fR environment variable is set when \fBsocranop\-session\-service\fR starts, \fBsocranop\-session\-service\fR uses its value instead of the \fB~/.config\fR part of the state file location.
+.IP
+Note that \fBsocranop\-session\-service\fR ignores \fBXDG_CONFIG_HOME\fR values passed via D\-Bus, which means that all D\-Bus clients use the same state file regardless of the D\-Bus clients \fBXDG_CONFIG_HOME\fR value.
+.\"
+.\" ======================================================================
+.\"
+.\" .SH NOTES
+.\"
+.\" ======================================================================
+.\"
+.SH BUGS
+For reading about known bugs and for filing new bugs, please go visit
+.UR https://github.com/socratools/socranop/issues
+.UE .
+.\"
+.\" ======================================================================
+.\"
+.SH EXAMPLES
+Usually, \fBsocranop\-session\-service\fR will be invoked by D\-Bus bus activation. This means you will rarely find yourself explictly running \fBsocranop\-session\-service\fR. The rare exception could be if something behaves weirdly and you want to help debug the problem by having \fBsocranop\-session\-service\fR print a few more messages than usual:
+
+    [user@host ~]$$ socranop\-session\-service \-\-verbose
+    AbstractDirs.__init__ UsrLocalDirs(chroot=None, prefix='/usr/local', datadir='/usr/local/share', statedir='/home/user/.config/socranop/state') chroot=None
+    [... several dozen lines cut ...]
+    <socranop.notepad.Notepad_12fx object at 0x7fadab48abb0> using existing stateFile /home/iser/.config/socranop/state/Notepad-12FX.state
+    Switching USB audio input to MASTER_L_R
+    Sending array('B', [0, 0, 4, 0, 3, 0, 0, 0])
+    self.stateFile PosixPath('/home/user/.config/socranop/state/Notepad-12FX.state')
+    Presenting Notepad-12FX (fw v1.09) on the session bus as /io/github/socratools/socranop/0
+    _
+.\"
+.\" ======================================================================
+.\"
+.SH SEE ALSO
+.BR socranop\-ctl (1),
+.BR socranop\-gui (1)
+.\"
+.\" ======================================================================
+.\"
+.\" THE END (of this man page).
+.\"
+.\" ======================================================================
+.\"

--- a/socranop/data/man/socranop-session-service.1
+++ b/socranop/data/man/socranop-session-service.1
@@ -87,16 +87,27 @@ See the state file description in the FILES section below.
 .\"
 .SH FILES
 .TP
+.\" The device path is Linux specific
+.BI /dev/bus/usb/ NNN / MMM
+The USB device file corresponding to the Notepad mixer. \fINNN\fR and \fIMMM\fR are decimal numbers. For more information on device permission setup, see the
+.\" FIXME: Substitute the proper path to PERMISSIONS.md here.
+.B PERMISSIONS.md
+file.
+.TP
 .B ~/.config/${PACKAGE}/state/*.state
 The state file is used to keep track of the state the device has been set to.
 .IP
 If the \fBXDG_CONFIG_HOME\fR environment variable is set when \fBsocranop\-session\-service\fR starts, \fBsocranop\-session\-service\fR uses its value instead of the \fB~/.config\fR part of the state file location.
 .IP
-Note that \fBsocranop\-session\-service\fR ignores \fBXDG_CONFIG_HOME\fR values passed via D\-Bus, which means that all D\-Bus clients use the same state file regardless of the D\-Bus clients \fBXDG_CONFIG_HOME\fR value.
+Note that \fBsocranop\-session\-service\fR ignores \fBXDG_CONFIG_HOME\fR values passed via D\-Bus, which means that all D\-Bus clients use the same state file by going through the D\-Bus service, regardless of the D\-Bus clients' \fBXDG_CONFIG_HOME\fR value.
 .\"
 .\" ======================================================================
 .\"
-.\" .SH NOTES
+.SH NOTES
+The USB device file must be readable and writable for the \fBsocranop\-session\-service\fR process. For more information on permission setup, see the
+.\" FIXME: Substitute the proper path to PERMISSIONS.md here.
+.B PERMISSIONS.md
+file.
 .\"
 .\" ======================================================================
 .\"
@@ -124,8 +135,9 @@ Usually, \fBsocranop\-session\-service\fR will be invoked by D\-Bus bus activati
 .\"
 .SH SEE ALSO
 .BR socranop\-ctl (1),
-.BR socranop\-gui (1)
-.\"
+.BR socranop\-gui (1),
+.\" FIXME: Substitute the proper path to PERMISSIONS.md here.
+.B PERMISSIONS.md
 .\" ======================================================================
 .\"
 .\" THE END (of this man page).

--- a/socranop/dbus.py
+++ b/socranop/dbus.py
@@ -330,6 +330,9 @@ class Client:
 
 
 def service_main():
+    # Caution: If you change the command line parser in any way,
+    #          update the man pages and bash completions accordingly.
+
     parser = argparse.ArgumentParser(description=f"The {const.PACKAGE} D-Bus service.")
     common.parser_args(parser)
 

--- a/socranop/gui.py
+++ b/socranop/gui.py
@@ -264,6 +264,9 @@ class App(Gtk.Application):
         )
         self.window = None
 
+        # Caution: If you change the command line parser in any way,
+        #          update the man pages and bash completions accordingly.
+
         self.add_main_option(
             "version",
             0,
@@ -288,6 +291,10 @@ class App(Gtk.Application):
         return 0
 
     def do_command_line(self, command_line):
+
+        # Caution: If you change the command line parser in any way,
+        #          update the man pages and bash completions accordingly.
+
         options = command_line.get_options_dict()
         # convert GVariantDict -> GVariant -> dict
         options = options.end().unpack()

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -618,6 +618,34 @@ class BashCompletionInstallTool(ResourceInstallTool):
         self.add_file(ResourceFile(dst, fullname))
 
 
+class ManpageInstallTool(ResourceInstallTool):
+    """Subsystem dealing with man pages"""
+
+    def __init__(self):
+        super(ManpageInstallTool, self).__init__()
+        self.template_data = {
+            "PACKAGE": const.PACKAGE,
+            "VERSION": const.VERSION,
+            "APPLICATION_ID": const.APPLICATION_ID,
+            "datadir": get_dirs().datadir,
+            "socranopdir": socranop.__path__[0],
+        }
+        self.walk_resources("man")
+
+    def mandir(self):
+        dirs = get_dirs()
+        return dirs.datadir / "man"
+
+    def add_resource(self, fullname):
+        mansrc = Path(fullname)
+        if fullname.endswith(".1"):
+            mandst = self.mandir() / "man1" / mansrc.name
+            manfile = TemplateFile(mandst, fullname, template_data=self.template_data)
+            self.add_file(manfile)
+        else:
+            raise UnhandledResource(fullname)
+
+
 class XDGDesktopInstallTool(ResourceInstallTool):
     """Subsystem dealing with the XDG desktop and icon files"""
 
@@ -851,6 +879,7 @@ def main():
     everything.add(CheckDependencies())
     everything.add(BashCompletionInstallTool())
     everything.add(DBusInstallTool(no_launch=args.no_launch))
+    everything.add(ManpageInstallTool())
     everything.add(XDGDesktopInstallTool())
     everything.add(UdevRulesInstallTool())
 

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -468,6 +468,8 @@ class ResourceInstallTool(FileInstallTool):
                 if resource_isdir(RESOURCE_MODULE, full_name):
                     walk_resource_subdir(f"{subdir}/{name}")
                 else:
+                    if full_name.endswith("~"):
+                        continue  # ignore editor backup files
                     self.add_resource(full_name)
 
         walk_resource_subdir(resdir)

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -818,6 +818,9 @@ class InstallToolEverything(AbstractInstallTool):
 
 
 def main():
+    # Caution: If you change the command line parser in any way,
+    #          update the man pages and bash completions accordingly.
+
     parser = argparse.ArgumentParser(
         description=f"hook {const.PACKAGE} into the system post-install (or do the reverse)"
     )

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -601,6 +601,23 @@ class DBusInstallTool(ResourceInstallTool):
         print("D-Bus service is unregistered")
 
 
+class BashCompletionInstallTool(ResourceInstallTool):
+    """Subsystem dealing with bash-completion files"""
+
+    def __init__(self):
+        super(BashCompletionInstallTool, self).__init__()
+
+        # TODO: What about /usr/local?
+        self.bc_dir = get_dirs().datadir / "bash-completion" / "completions"
+
+        self.walk_resources("bash-completion")
+
+    def add_resource(self, fullname):
+        src = Path(fullname)
+        dst = self.bc_dir / src.name
+        self.add_file(ResourceFile(dst, fullname))
+
+
 class XDGDesktopInstallTool(ResourceInstallTool):
     """Subsystem dealing with the XDG desktop and icon files"""
 
@@ -832,6 +849,7 @@ def main():
 
     everything = InstallToolEverything()
     everything.add(CheckDependencies())
+    everything.add(BashCompletionInstallTool())
     everything.add(DBusInstallTool(no_launch=args.no_launch))
     everything.add(XDGDesktopInstallTool())
     everything.add(UdevRulesInstallTool())


### PR DESCRIPTION
Add man pages for the executables used at run time

  * socranop-ctl(1)

  * socranop-gui(1)

  * socranop-session-service(1)
    Yes, section 1 as it is user runnable. (Is this valid argument? Update. It is.)

and (un)install them with `socranop-installtool`.

There is no man page for `socranop-installtool`, as that
is not used after package installation and prepared packages
are expected not to ship it.