### PR TITLE
Add bash-completion for all four exectuables

### DIFF
--- a/socranop/data/bash-completion/socranop-ctl
+++ b/socranop/data/bash-completion/socranop-ctl
@@ -1,0 +1,20 @@
+# bash completion script for the socranop-ctl command   -*- shell-script -*-
+
+_socranop_ctl()
+{
+    # $1 is the command name
+    # $2 is the word being completed
+    # $3 is the preceding word
+    case "$3" in
+	socranop-ctl | */socranop-ctl)
+	    COMPREPLY=($(compgen -W "-h --help --version -v --verbose --no-dbus -l --list -s --set" -- "$2"))
+	    return
+	    ;;
+        -s | --set)
+            COMPREPLY=($(compgen -W "0 1 2 3" -- "$2"))
+            return
+	    ;;
+    esac
+    return
+} &&
+    complete -F _socranop_ctl "socranop-ctl"

--- a/socranop/data/bash-completion/socranop-gui
+++ b/socranop/data/bash-completion/socranop-gui
@@ -1,0 +1,17 @@
+# bash completion script for the socranop-gui command   -*- shell-script -*-
+
+_socranop_gui()
+{
+    # $1 is the command name
+    # $2 is the word being completed
+    # $3 is the preceding word
+    case "$3" in
+	socranop-gui | */socranop-gui)
+	    # only common completions, other options need to be typed in
+	    COMPREPLY=($(compgen -W "-h --help --help-all --version -v --verbose" -- "$2"))
+	    return
+	    ;;
+    esac
+    return
+} &&
+    complete -F _socranop_gui "socranop-gui"

--- a/socranop/data/bash-completion/socranop-installtool
+++ b/socranop/data/bash-completion/socranop-installtool
@@ -1,0 +1,67 @@
+# bash completion script for the socranop-installtool command   -*- shell-script -*-
+
+_socranop_installtool()
+{
+    # $1 is the command name
+    # $2 is the word being completed
+    # $3 is the preceding word
+    local i word
+    local ALL_OPTIONS REMAINING_OPTIONS
+    declare -A REMAINING_OPTIONS
+
+    ALL_OPTIONS=(-h --help --version -v --verbose --post-install --pre-uninstall --no-launch --chroot --sudo-script)
+
+    case "$3" in
+	# socranop-installtool | */socranop-installtool)
+	#     COMPREPLY=($(compgen -W "${ALL_OPTIONS[*]}" -- "$2"))
+	#     return 0
+	#     ;;
+	--chroot)
+	    COMPREPLY=($(compgen -A directory -- "$2"))
+	    return 0
+	    ;;
+	--sudo-script)
+	    COMPREPLY=($(compgen -A file -- "$2"))
+	    return 0
+	    ;;
+    esac
+
+    for word in "${ALL_OPTIONS[@]}"
+    do
+	REMAINING_OPTIONS["$word"]=moo
+    done
+
+    for i in $(seq 0 "$(( $COMP_CWORD - 1 ))")
+    do
+	word="${COMP_WORDS[$i]}"
+	case "$word" in
+	    -h | --help | --version)
+		COMPREPLY=()
+		return 0
+		;;
+	    -v | --verbose)
+		unset REMAINING_OPTIONS["-v"]
+		unset REMAINING_OPTIONS["--verbose"]
+		;;
+	    --post-install)
+		unset REMAINING_OPTIONS["$word"]
+		unset REMAINING_OPTIONS["--pre-uninstall"]
+		;;
+	    --pre-uninstall)
+		unset REMAINING_OPTIONS["$word"]
+		unset REMAINING_OPTIONS["--post-install"]
+		;;
+	    --chroot)
+		unset REMAINING_OPTIONS["$word"]
+		unset REMAINING_OPTIONS["--no-launch"]
+		;;
+	    *)
+		unset REMAINING_OPTIONS["$word"]
+		;;
+	esac
+    done
+
+    COMPREPLY=($(compgen -W "${!REMAINING_OPTIONS[*]}" -- "$2"))
+    return 0
+} &&
+    complete -F _socranop_installtool "socranop-installtool"

--- a/socranop/data/bash-completion/socranop-session-service
+++ b/socranop/data/bash-completion/socranop-session-service
@@ -1,0 +1,16 @@
+# bash completion script for the socranop-session-service command   -*- shell-script -*-
+
+_socranop_session_service()
+{
+    # $1 is the command name
+    # $2 is the word being completed
+    # $3 is the preceding word
+    case "$3" in
+	socranop-session-service | */socranop-session-service)
+	    COMPREPLY=($(compgen -W "-h --help --version -v --verbose" -- "$2"))
+	    return
+	    ;;
+    esac
+    return
+} &&
+    complete -F _socranop_session_service "socranop-session-service"

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -468,6 +468,8 @@ class ResourceInstallTool(FileInstallTool):
                 if resource_isdir(RESOURCE_MODULE, full_name):
                     walk_resource_subdir(f"{subdir}/{name}")
                 else:
+                    if full_name.endswith("~"):
+                        continue  # ignore editor backup files
                     self.add_resource(full_name)
 
         walk_resource_subdir(resdir)

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -601,6 +601,23 @@ class DBusInstallTool(ResourceInstallTool):
         print("D-Bus service is unregistered")
 
 
+class BashCompletionInstallTool(ResourceInstallTool):
+    """Subsystem dealing with bash-completion files"""
+
+    def __init__(self):
+        super(BashCompletionInstallTool, self).__init__()
+
+        # TODO: What about /usr/local?
+        self.bc_dir = get_dirs().datadir / "bash-completion" / "completions"
+
+        self.walk_resources("bash-completion")
+
+    def add_resource(self, fullname):
+        src = Path(fullname)
+        dst = self.bc_dir / src.name
+        self.add_file(ResourceFile(dst, fullname))
+
+
 class XDGDesktopInstallTool(ResourceInstallTool):
     """Subsystem dealing with the XDG desktop and icon files"""
 
@@ -832,6 +849,7 @@ def main():
 
     everything = InstallToolEverything()
     everything.add(CheckDependencies())
+    everything.add(BashCompletionInstallTool())
     everything.add(DBusInstallTool(no_launch=args.no_launch))
     everything.add(XDGDesktopInstallTool())
     everything.add(UdevRulesInstallTool())


### PR DESCRIPTION
Add bash-completion for the three normal executables:

  * socranop-ctl
  * socranop-gui
  * socranop-session-service

and for the special case of

  * socranop-installtool

The latter is not strictly required and useless before `socranop-installtool` actually installs the bash-completion file for itself, but can be useful for uninstalling and while developing.