### PR TITLE
Stop handling obsolete files

### DIFF
--- a/socranop/constants.py
+++ b/socranop/constants.py
@@ -54,7 +54,6 @@ MGRPATH = "/io/github/socratools/socranop"
 
 
 # Helpful for removing remnants of soundcraft-utils 0.4.0 and earlier
-OLD_BASE_EXE_SERVICE = "soundcraft_dbus_service"
 OLD_STATEDIR = "/var/lib/soundcraft-utils"
 
 

--- a/socranop/constants.py
+++ b/socranop/constants.py
@@ -53,10 +53,6 @@ SERVICE_INTERFACE = BUSNAME
 MGRPATH = "/io/github/socratools/socranop"
 
 
-# Helpful for removing remnants of soundcraft-utils 0.4.0 and earlier
-OLD_STATEDIR = "/var/lib/soundcraft-utils"
-
-
 # USB Device vendor and product IDs
 VENDOR_ID_HARMAN = 0x05FC
 

--- a/socranop/notepad.py
+++ b/socranop/notepad.py
@@ -23,7 +23,6 @@
 import array
 import enum
 import json
-import shutil
 
 from pathlib import Path
 
@@ -61,24 +60,6 @@ class NotepadBase:
                 self.product = self.__class__.__name__
             self.fwVersion = "%d.%02d" % (major, minor)
             self.stateFile = stateDir / f"{self.product}.state"
-            if self.stateFile.exists():
-                debug(self, "using existing stateFile", self.stateFile)
-            else:
-                # If self.stateFile does not exist, import the state
-                # file from the old /var/lib location if one exists.
-                # TODO: This should be removed some time in the future (seen from 2020-11).
-                oldStateFile = Path(const.OLD_STATEDIR) / f"{self.product}.state"
-                if oldStateFile.exists():
-                    debug(
-                        self,
-                        "using stateFile",
-                        self.stateFile,
-                        "copied over from old",
-                        oldStateFile,
-                    )
-                    shutil.copy(oldStateFile, self.stateFile)
-                else:
-                    debug(self, "using new stateFile", self.stateFile)
             self.state = {}
             self._loadState()
 


### PR DESCRIPTION
As @lack suggested in the review for the `session-dbus` merge, this gets rid of all the code dealing with remainders of old `soundcraft-utils`: global state files, system D-Bus service processes and executables, etc.

We have a completely new name and D-Bus namespace now, so there are no collisions any more.

Users can uninstall soundcraft-utils however they please, or leave the files lying around unused.