### PR TITLE
Stop shipping backup files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+# https://packaging.python.org/guides/using-manifest-in/
+global-include *.md
+prune .github
+prune .pytest_cache
+prune .tox
+recursive-include socranop/data *
+global-exclude *~

--- a/contrib/dist-checks
+++ b/contrib/dist-checks
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+cd "$(dirname "$(dirname "$0")")"
+
+set -ex
+
+PYTHON=python3
+
+fullname="$(${PYTHON} setup.py --fullname)"
+
+${PYTHON} setup.py clean --all
+
+
+${PYTHON} setup.py sdist
+
+${PYTHON} setup.py bdist_wheel
+
+
+tgz_file="dist/${fullname}.tar.gz"
+test -f "$tgz_file"
+
+tar tvfz "$tgz_file" | grep '~$' > "dist/${fullname}.tgz-backup-files" ||:
+if test -s "dist/${fullname}.tgz-backup-files"; then
+    cat "dist/${fullname}.tgz-backup-files"
+    exit 2
+fi
+
+
+whl_file="$(for f in dist/${fullname}-py3-*.whl; do if test -f "$f"; then echo "$f"; break; fi; done)"
+test -f "$whl_file"
+
+unzip -l "$whl_file" | grep '~$' > "dist/${fullname}.whl-backup-files" ||:
+if test -s "dist/${fullname}.whl-backup-files"; then
+    cat "dist/${fullname}.whl-backup-files"
+    exit 2
+fi

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,5 @@ setup(
         ],
         "gui_scripts": [f"{const.BASE_EXE_GUI}=socranop.gui:main"],
     },
-    package_data={"socranop": ["data/*/*/*", "data/*/*"]},
+    include_package_data=True,
 )


### PR DESCRIPTION
While writing permission docs which are both in the top level directory and can still be installed, I examined the generated source tarball and wheel zip files, and found a number of editor backup files ending in a tilde (`*~`).

These files should not end up in source or binary distribution artifacts.

Also, the `.github` hooks and `.pytest-cache` and `.tox` cache directories should not be in distribution artifacts, either.
