### PR TITLE
dbus shutdown fix

### DIFF
--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -148,6 +148,9 @@ class Step:
         return False
 
 
+MAX_ATTEMPTS = 5
+
+
 class ScriptCommand:
     """A single command which may need to be run in a sudo script
 
@@ -697,7 +700,9 @@ class DBusInstallTool(ResourceInstallTool):
             service = self._service(const.BUSNAME)
             service_version = service.version
             with Step(
-                "stop", f"Shutting down version {service_version}", max_attempts=5
+                "stop",
+                f"Shutting down running service version {service_version}",
+                max_attempts=MAX_ATTEMPTS,
             ) as step:
                 service.Shutdown()
                 # Wait until the shutdown clears the service off the bus
@@ -719,8 +724,8 @@ class DBusInstallTool(ResourceInstallTool):
         with Step(
             "verify",
             "Checking for registered service",
-            error_msg="The dbus service we just installed has not yet been detected after 5s. You may need to restart your dbus session (for example, by logging out and back in to your desktop).",
-            max_attempts=5,
+            error_msg=f"The dbus service we just installed has not yet been detected after {MAX_ATTEMPTS}s. You may need to restart your dbus session (for example, by logging out and back in to your desktop).",
+            max_attempts=MAX_ATTEMPTS,
         ) as step:
             while const.BUSNAME not in dbus_service.ListActivatableNames():
                 step.try_again()

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -676,9 +676,10 @@ class DBusInstallTool(ResourceInstallTool):
             raise UnhandledResource(fullname)
 
     def post_install(self):
+        self._print_heading("Configuring")
         self.shutdown_service("Stopping old service")
 
-        super(DBusInstallTool, self).post_install()
+        super(DBusInstallTool, self)._do_install()
 
         self.verify_install()
 
@@ -693,7 +694,6 @@ class DBusInstallTool(ResourceInstallTool):
         if not dbus_service.NameHasOwner(const.BUSNAME):
             common.debug("D-Bus service not running")
         else:
-            self._print_heading(reason)
             service = self._service(const.BUSNAME)
             service_version = service.version
             with Step(
@@ -708,8 +708,6 @@ class DBusInstallTool(ResourceInstallTool):
         if self.no_launch and not force:
             common.debug("no_launch is set; not verifying our dbus service")
             return
-
-        self._print_heading("Verifying")
 
         dbus_service = self._service(".DBus")
         with Step("verify", "Reload dbus to register the new service"):
@@ -745,8 +743,10 @@ class DBusInstallTool(ResourceInstallTool):
             our_service.Shutdown()
 
     def pre_uninstall(self):
+        self._print_heading("Configuring")
         self.shutdown_service("Stopping service")
-        super(DBusInstallTool, self).pre_uninstall()
+        super(DBusInstallTool, self)._do_uninstall()
+        self._print_heading("Complete")
 
 
 class BashCompletionInstallTool(ResourceInstallTool):

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -731,7 +731,7 @@ class DBusInstallTool(ResourceInstallTool):
             service_version = our_service.version
             step.set_success_word(service_version)
 
-        with Step("verify", "Installtool version", success_word=const.VERSION):
+        with Step("verify", "Installtool    version", success_word=const.VERSION):
             pass
 
         # TODO: Compare versions?  Fail if there's a mismatch?

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -110,7 +110,7 @@ class Step:
     def set_success_word(self, success_word):
         self.success_word = success_word
 
-    def try_again(self, sleep):
+    def try_again(self):
         self.attempt += 1
         if self.attempt > self.max_attempts:
             self.attempt = self.max_attempts
@@ -121,7 +121,7 @@ class Step:
             "not yet", postfix=f"(attempt {self.attempt}/{self.max_attempts})", end="\r"
         )
         self.__step_start(self.tag, self.details)
-        time.sleep(sleep)
+        time.sleep(1)
 
     def __enter__(self):
         self.__step_start(self.tag, self.details)
@@ -702,7 +702,7 @@ class DBusInstallTool(ResourceInstallTool):
                 service.Shutdown()
                 # Wait until the shutdown clears the service off the bus
                 while dbus_service.NameHasOwner(const.BUSNAME):
-                    step.try_again(sleep=1)
+                    step.try_again()
 
     def verify_install(self, force=False):
         if self.no_launch and not force:
@@ -723,7 +723,7 @@ class DBusInstallTool(ResourceInstallTool):
             max_attempts=5,
         ) as step:
             while const.BUSNAME not in dbus_service.ListActivatableNames():
-                step.try_again(sleep=1)
+                step.try_again()
 
         # Just using the service proves auto-start works:
         with Step("verify", "Starting D-Bus service") as step:


### PR DESCRIPTION
- Roll attempt-counting logic into Step.try_again() 
- Wait for the D-Bus service to leave the bus after 
shutdown

If we don't wait for the bus to be clear, there's a race against the possibility that the next client we start up will see this nearly-gone service instead of launching a new one as we intend.  The client will also throw exceptions if that happens as the old service is removed from the bus.

