### PR TITLE
Add --wait option to socranop-ctl

### DIFF
--- a/socranop/cli.py
+++ b/socranop/cli.py
@@ -26,16 +26,19 @@ import sys
 import socranop.common as common
 
 
-def autodetect(dbus=True):
+def autodetect(dbus=True, wait=False):
     if dbus:
         try:
             from socranop.dbus import Client, DbusInitializationError
 
             client = Client()
             result = client.autodetect()
-            if result is None:
+            if result is None and wait:
                 print("No devices found... waiting for one to appear")
-                result = client.waitForDevice()
+                try:
+                    result = client.waitForDevice()
+                except KeyboardInterrupt:
+                    pass
             return result
         except DbusInitializationError as e:
             print(e)
@@ -97,6 +100,12 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "-w",
+        "--wait",
+        help="If no compatible device is found, wait for one to appear",
+        action="store_true",
+    )
+    parser.add_argument(
         "-l",
         "--list",
         help="List the available source routing options",
@@ -108,7 +117,7 @@ def main():
     args = parser.parse_args()
     common.VERBOSE = args.verbose
     if args.list or args.set:
-        dev = autodetect(dbus=not args.no_dbus)
+        dev = autodetect(dbus=not args.no_dbus, wait=args.wait)
         if dev is None:
             print("No compatible device detected")
             sys.exit(1)

--- a/socranop/cli.py
+++ b/socranop/cli.py
@@ -46,7 +46,12 @@ def autodetect(dbus=True, wait=False):
     else:
         import socranop.notepad
 
-        return socranop.notepad.autodetect()
+        result = socranop.notepad.autodetect()
+        if result is None and wait:
+            print(
+                "Warning: '--wait' only works with D-Bus.  Exiting immediately instead."
+            )
+        return result
 
 
 def max_lengths(dev):
@@ -102,7 +107,7 @@ def main():
     parser.add_argument(
         "-w",
         "--wait",
-        help="If no compatible device is found, wait for one to appear",
+        help="If no compatible device is found, wait for one to appear (D-Bus mode only)",
         action="store_true",
     )
     parser.add_argument(

--- a/socranop/data/bash-completion/socranop-ctl
+++ b/socranop/data/bash-completion/socranop-ctl
@@ -7,7 +7,7 @@ _socranop_ctl()
     # $3 is the preceding word
     case "$3" in
 	socranop-ctl | */socranop-ctl)
-	    COMPREPLY=($(compgen -W "-h --help --version -v --verbose --no-dbus -l --list -s --set" -- "$2"))
+	    COMPREPLY=($(compgen -W "-h --help --version -v --verbose --no-dbus -w --wait -l --list -s --set" -- "$2"))
 	    return
 	    ;;
         -s | --set)

--- a/socranop/data/man/socranop-ctl.1
+++ b/socranop/data/man/socranop-ctl.1
@@ -25,6 +25,7 @@ socranop\-ctl \- control Soundcraft Notepad series mixer USB audio routing from 
 .\"   --no-dbus          Use direct USB device access instead of D-Bus service
 .\"                      access
 .\"   -w, --wait         If no compatible device is found, wait for one to appear
+.\"                      (D-Bus mode only)
 .\"   -l, --list         List the available source routing options
 .\"   -s SET, --set SET  Set the specified source to route to the USB capture
 .\"                      input
@@ -67,7 +68,7 @@ Access the USB directly without going through the
 D-Bus service.
 .TP
 .RB (\| \-w | \-\-wait \|)
-If no compatible device is found, wait for one to appear
+If no compatible device is found, wait for one to appear (D-Bus mode only)
 .TP
 .RB (\| \-v | \-\-verbose \|)
 Make the program output more information. Helpful for debugging.

--- a/socranop/data/man/socranop-ctl.1
+++ b/socranop/data/man/socranop-ctl.1
@@ -16,7 +16,7 @@ socranop\-ctl \- control Soundcraft Notepad series mixer USB audio routing from 
 .\"
 .\" ======================================================================
 .\"
-.\" usage: socranop-ctl [-h] [--version] [--no-dbus] [-l] [-s SET]
+,\" usage: socranop-ctl [-h] [--version] [-v] [--no-dbus] [-w] [-l] [-s SET]
 .\"
 .\" optional arguments:
 .\"   -h, --help         show this help message and exit
@@ -24,6 +24,7 @@ socranop\-ctl \- control Soundcraft Notepad series mixer USB audio routing from 
 .\"   -v, --verbose      Enable more verbose output, largely for debugging
 .\"   --no-dbus          Use direct USB device access instead of D-Bus service
 .\"                      access
+.\"   -w, --wait         If no compatible device is found, wait for one to appear
 .\"   -l, --list         List the available source routing options
 .\"   -s SET, --set SET  Set the specified source to route to the USB capture
 .\"                      input
@@ -35,11 +36,13 @@ socranop\-ctl \- control Soundcraft Notepad series mixer USB audio routing from 
 .B "socranop\-ctl"
 .RB [\| \-\-verbose \|]
 .RB [\| \-\-no\-dbus \|]
+.RB [\| \-\-wait \|]
 .B \-\-list
 .br
 .B "socranop\-ctl"
 .RB [\| \-\-verbose \|]
 .RB [\| \-\-no\-dbus \|]
+.RB [\| \-\-wait \|]
 .BI \-\-set\  SOURCE
 .\"
 .\" ======================================================================
@@ -62,6 +65,9 @@ Print the program version and exit.
 Access the USB directly without going through the
 .B socranop\-session\-service
 D-Bus service.
+.TP
+.RB (\| \-w | \-\-wait \|)
+If no compatible device is found, wait for one to appear
 .TP
 .RB (\| \-v | \-\-verbose \|)
 Make the program output more information. Helpful for debugging.

--- a/socranop/dbus.py
+++ b/socranop/dbus.py
@@ -192,8 +192,11 @@ class Service:
 
     def uevent(self, observer, action, device):
         if action == "add":
-            idVendor = int(device.get_property("ID_VENDOR_ID"), 16)
-            idProduct = int(device.get_property("ID_PRODUCT_ID"), 16)
+            idVStr = device.get_property("ID_VENDOR_ID")
+            idPStr = device.get_property("ID_PRODUCT_ID")
+            common.debug(f"Device added (idVendor={idVStr!r}, idProduct={idPStr!r})")
+            idVendor = int(idVStr, 16)
+            idProduct = int(idPStr, 16)
             if idVendor == const.VENDOR_ID_HARMAN:
                 print(
                     f"Checking new Soundcraft device ({idVendor:0>4x}:{idProduct:0>4x})..."

--- a/socranop/dbus.py
+++ b/socranop/dbus.py
@@ -193,7 +193,7 @@ class Service:
     def uevent(self, observer, action, device):
         if action == "add":
             idVStr = device.get_property("ID_VENDOR_ID")
-            idPStr = device.get_property("ID_PRODUCT_ID")
+            idPStr = device.get_property("ID_MODEL_ID")
             common.debug(f"Device added (idVendor={idVStr!r}, idProduct={idPStr!r})")
             idVendor = int(idVStr, 16)
             idProduct = int(idPStr, 16)


### PR DESCRIPTION
The default behavior is now to exit (with error code) if no device
exists.
