### PR TITLE
Remove image links for pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,14 +202,12 @@ The GUI can also be started manually via:
 socranop-gui
 ```
 
-#### Usage Tips
+Some usage tips:
 
 - Select the desired input using the up and down arrow keys or using the mouse
 - Apply the selection by clicking "Apply" (ALT+A)
 - Instead of applying the selection, clicking "Reset" (ALT+R) will set the
   selection back to the current state of the mixer (if known)
-
-#### Screenshots
 
 ![GUI Window](images/gui-screenshot.png)
 ![GUI Window with drop-down open](images/gui-screenshot-with-dropdown.png)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,12 @@ if not topdir_from_setup.samefile(topdir_from_const):
     )
 
 readme_md_path = topdir_from_setup / "README.md"
-long_description = readme_md_path.read_text("utf-8")
+readme_text = readme_md_path.read_text("utf-8")
+
+# Filter out screenshot images which do work on github, but not on pypi
+long_description = "".join(
+    [f"{line}\n" for line in readme_text.splitlines() if not line.startswith("![")]
+)
 
 setup(
     name=const.PACKAGE,


### PR DESCRIPTION
As the [pypi socranop page](https://pypi.org/project/socranop/) does not show the screenshots linked to from README.md, we can remove the image links from the `text/markdown` `long_description` altogether and thus improve the HTML output from:

    GUI Window   GUI Window with dropdown open

to nothing, which is better.

TODO: The above are actually broken image links to URLs like `https://warehouse-camo.ingress.cmh1.psfhosted.org/6d92dda63c273069c857705f954cbc7535765782/6775692d73637265656e73686f742d776974682d64726f70646f776e2e706e67` which just return "Not Found". Is this to be expected, or can this be fixed?

There is no testing required for this. How removing text from README.md will change the pypi socranop page can be predicted reasonably well.

Alternatives:
  * do nothing
  * https://github.com/socratools/socranop/pull/52
  * https://github.com/socratools/socranop/pull/54