### PR TITLE
socranop-gui(1): Fix icon location in chrooted environments

### DIFF
--- a/socranop/data/man/socranop-gui.1
+++ b/socranop/data/man/socranop-gui.1
@@ -98,7 +98,7 @@ If successful, returns 0. Nonzero exit codes indicate an error.
 .SH FILES
 .TP
 .B ${datadir}/icons/hicolor/256x256/apps/${APPLICATION_ID}.png
-One location where \fBsocranop\-gui\fR looks for its application icon.
+Preferred location where \fBsocranop\-gui\fR looks for its application icon.
 .TP
 .B ${socranopdir}/data/xdg/${APPLICATION_ID}.256.png
 Fallback location where \fBsocranop\-gui\fR looks for its application icon.

--- a/socranop/dirs.py
+++ b/socranop/dirs.py
@@ -94,7 +94,7 @@ class AbstractDirs(metaclass=abc.ABCMeta):
     def chroot(self):
         return self._chroot
 
-    def __remove_chroot(self, path):
+    def remove_chroot(self, path):
         if self.chroot is None:
             return path
         else:
@@ -112,12 +112,12 @@ class AbstractDirs(metaclass=abc.ABCMeta):
     @property
     def guiExePath(self):
         """Full path to the gui script executable"""
-        return self.__remove_chroot(self.exePath.parent / const.BASE_EXE_GUI)
+        return self.remove_chroot(self.exePath.parent / const.BASE_EXE_GUI)
 
     @property
     def serviceExePath(self):
         """Full path to the service script executable"""
-        return self.__remove_chroot(self.exePath.parent / const.BASE_EXE_SERVICE)
+        return self.remove_chroot(self.exePath.parent / const.BASE_EXE_SERVICE)
 
     def __detect(self):
         """Detect whether the current installation matches this class.

--- a/socranop/installtool.py
+++ b/socranop/installtool.py
@@ -770,12 +770,13 @@ class ManpageInstallTool(ResourceInstallTool):
 
     def __init__(self):
         super(ManpageInstallTool, self).__init__(heading="Man pages")
+        dirs = get_dirs()
         self.template_data = {
             "PACKAGE": const.PACKAGE,
             "VERSION": const.VERSION,
             "APPLICATION_ID": const.APPLICATION_ID,
-            "datadir": get_dirs().datadir,
-            "socranopdir": socranop.__path__[0],
+            "datadir": dirs.datadir,
+            "socranopdir": dirs.remove_chroot(Path(socranop.__path__[0])),
         }
         self.walk_resources("man")
 


### PR DESCRIPTION
If `socranop-installtool` runs with `--chroot=CHROOT`, the fallback location of the `socranop-gui` icon file will be inside the chroot, so `socranop-installtool` needs to remove the chroot part from the path of the icon it substitutes into the man page.