### PR TITLE
ci: Make "pip install pygit2" work again

### DIFF
--- a/.github/workflows/commit-checks.yaml
+++ b/.github/workflows/commit-checks.yaml
@@ -19,7 +19,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.x
-    - name: Install dependencies
+    - name: 'Install OS build requirements (Linux)'
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgit2-dev
+    - name: Install Pip dependencies
       run: |
         python -m pip install --upgrade pipenv
         pipenv install --dev

--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ pipenv-setup = "*"
 pre-commit = "*"
 chardet = "*"
 twine = "*"
-pygit2 = "*"
+pygit2 = "< 1.7.0"
 vistir = "< 0.7.0"
 
 [pipenv]


### PR DESCRIPTION
Install libgit2-dev before pip installs pygit2, and limit the pygit2 version in Pipfile such that pip can build pygit2 with the old libgit2-dev Ubuntu 22.04 comes with.

I have no idea why this appears to not have been necessary in the past.