### PR TITLE
Revert "Pipfile: Require pygit2 < 1.7.0 for older libgit2 on Ubuntu 2…

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ pipenv-setup = "*"
 pre-commit = "*"
 chardet = "*"
 twine = "*"
-pygit2 = "< 1.7.0"
+pygit2 = "*"
 vistir = "< 0.7.0"
 
 [pipenv]


### PR DESCRIPTION
This reverts commit a53e634409f8db391eb71c117551d5494e3c1876.

It appears that the issue we had the above commit tried to resolve
on Ubuntu regarding libgit2 and pygit2 has resolved by itself just
like it appeared by itself.

However, as a53e634409f8db391eb71c117551d5494e3c1876 broke on my
Fedora 39 system, reverting makes sense.

At least until the next time something breaks.

See also https://github.com/socratools/socranop/pull/67